### PR TITLE
feat: Make frontend URL configurable for login redirects

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,17 @@
+# This is an example .env file.
+# Copy this file to .env and fill in your actual credentials.
+
+# MongoDB connection string
+MONGO_URL="mongodb://localhost:27017"
+DB_NAME="test_database"
+
+# LinkedIn OAuth credentials
+LINKEDIN_CLIENT_ID="YOUR_LINKEDIN_CLIENT_ID"
+LINKEDIN_CLIENT_SECRET="YOUR_LINKEDIN_CLIENT_SECRET"
+
+# The publicly accessible base URL of your frontend application
+FRONTEND_URL="https://your-frontend-domain.com"
+
+# The publicly accessible base URL of your backend API
+# (e.g., https://your-backend-domain.com/api or http://localhost:8001/api if Nginx is not in front for local dev)
+BACKEND_URL="https://your-backend-domain.com/api"

--- a/backend/server.py
+++ b/backend/server.py
@@ -31,9 +31,11 @@ api_router = APIRouter(prefix="/api")
 # LinkedIn OAuth Configuration
 LINKEDIN_CLIENT_ID = os.getenv('LINKEDIN_CLIENT_ID')
 LINKEDIN_CLIENT_SECRET = os.getenv('LINKEDIN_CLIENT_SECRET')
-FRONTEND_URL = "https://cf80c52e-5751-499f-940c-f2a1ff6b2f54.preview.emergentagent.com"
+FRONTEND_URL_DEFAULT = "https://cf80c52e-5751-499f-940c-f2a1ff6b2f54.preview.emergentagent.com"
+FRONTEND_URL = os.getenv('FRONTEND_URL', FRONTEND_URL_DEFAULT)
 # Backend URL should point to the API endpoints - same domain but with /api prefix
-BACKEND_URL = "https://cf80c52e-5751-499f-940c-f2a1ff6b2f54.preview.emergentagent.com/api"
+BACKEND_URL_DEFAULT = "https://cf80c52e-5751-499f-940c-f2a1ff6b2f54.preview.emergentagent.com/api"
+BACKEND_URL = os.getenv('BACKEND_URL', BACKEND_URL_DEFAULT)
 REDIRECT_URI = f"{FRONTEND_URL}/api/auth/linkedin/callback"
 
 # Define Models


### PR DESCRIPTION
I've modified `backend/server.py` to source `FRONTEND_URL` and `BACKEND_URL` from environment variables, falling back to previously hardcoded values if the variables are not set. This allows for greater flexibility in deploying the application, especially in environments with dynamic URLs.

The `REDIRECT_URI` for LinkedIn OAuth is generated using this `FRONTEND_URL`.

I've also added `FRONTEND_URL` and `BACKEND_URL` to `backend/.env.example` to document these new configuration options.

Important:
Ensure that the "Authorized redirect URIs" in your LinkedIn OAuth application settings exactly match the `REDIRECT_URI` generated by the backend. With this change, this will be
`YOUR_FRONTEND_URL/api/auth/linkedin/callback`
(e.g., `https://your-actual-frontend.com/api/auth/linkedin/callback`).